### PR TITLE
Potential fix for code scanning alert no. 2: Possible loss of precision

### DIFF
--- a/src/SemanticKernel.Agents.Memory.Core/ImportOrchestrator.cs
+++ b/src/SemanticKernel.Agents.Memory.Core/ImportOrchestrator.cs
@@ -127,7 +127,7 @@ public sealed class ImportOrchestrator : BaseOrchestrator
                         _logger?.LogWarning("Pipeline step '{StepName}' failed with transient error for document {DocumentId}, retrying (attempt {Attempt}/{MaxRetries})", 
                             stepName, pipeline.DocumentId, attempt, maxRetriesPerStep);
                         
-                        await Task.Delay(TimeSpan.FromMilliseconds(200 * attempt), ct).ConfigureAwait(false);
+                        await Task.Delay(TimeSpan.FromMilliseconds(200.0 * attempt), ct).ConfigureAwait(false);
                         continue; // retry same step
                     }
                     else


### PR DESCRIPTION
Potential fix for [https://github.com/kbeaugrand/SemanticKernel.Agents.Memory/security/code-scanning/2](https://github.com/kbeaugrand/SemanticKernel.Agents.Memory/security/code-scanning/2)

To address this potential loss of precision or overflow, we should ensure that at least one operand of the multiplication is explicitly cast to a floating-point type (`double`). This will direct the compiler to perform floating-point multiplication, avoiding integer overflow. Given that `TimeSpan.FromMilliseconds` can accept a double, the best way to fix the issue is to cast `attempt` (or `200`) to a double, so the multiplication is performed in floating-point. The smallest edit with the least functional impact is to change `200 * attempt` to `200.0 * attempt` on line 130 in `src/SemanticKernel.Agents.Memory.Core/ImportOrchestrator.cs`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
