### PR TITLE
Potential fix for code scanning alert no. 1: Possible loss of precision

### DIFF
--- a/src/SemanticKernel.Agents.Memory.Core/ImportOrchestrator.cs
+++ b/src/SemanticKernel.Agents.Memory.Core/ImportOrchestrator.cs
@@ -149,7 +149,7 @@ public sealed class ImportOrchestrator : BaseOrchestrator
                     _logger?.LogWarning(ex, "Pipeline step '{StepName}' threw exception for document {DocumentId}, retrying (attempt {Attempt}/{MaxRetries})", 
                         stepName, pipeline.DocumentId, attempt, maxRetriesPerStep);
                     
-                    await Task.Delay(TimeSpan.FromMilliseconds(200 * attempt), ct).ConfigureAwait(false);
+                    await Task.Delay(TimeSpan.FromMilliseconds(200 * (double)attempt), ct).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Potential fix for [https://github.com/kbeaugrand/SemanticKernel.Agents.Memory/security/code-scanning/1](https://github.com/kbeaugrand/SemanticKernel.Agents.Memory/security/code-scanning/1)

To fix the possible loss of precision and avoid potential overflow, one of the operands in the multiplication on line 152 should be explicitly cast to a floating-point type (`double` or `float`). This ensures that the multiplication is performed in floating-point arithmetic, and prevents overflow if `attempt` is larger than `int.MaxValue / 200`. The best way is to cast `attempt` to `double`, i.e., replace `200 * attempt` with `200 * (double)attempt`.  
Edit only line 152 in `src/SemanticKernel.Agents.Memory.Core/ImportOrchestrator.cs`, no new methods or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
