### PR TITLE
Potential fix for code scanning alert no. 82: Useless assignment to local variable

### DIFF
--- a/src/SemanticKernel.Agents.Memory.Core/Handlers/SaveRecordsHandler.cs
+++ b/src/SemanticKernel.Agents.Memory.Core/Handlers/SaveRecordsHandler.cs
@@ -84,7 +84,7 @@ public sealed class SaveRecordsHandler<TVectorStore> : IPipelineStepHandler
                 }
 
                 // Get the embedding from the context
-                ReadOnlyMemory<float> embedding = ReadOnlyMemory<float>.Empty;
+                ReadOnlyMemory<float> embedding;
                 string embeddingKey = $"embedding_{file.Id}";
 
                 if (pipeline.ContextArguments.TryGetValue(embeddingKey, out var embeddingValue) && embeddingValue is float[] embeddingArray)


### PR DESCRIPTION
Potential fix for [https://github.com/kbeaugrand/SemanticKernel.Agents.Memory/security/code-scanning/82](https://github.com/kbeaugrand/SemanticKernel.Agents.Memory/security/code-scanning/82)

To fix the problem, simply remove the unnecessary initialization of the `embedding` variable to `ReadOnlyMemory<float>.Empty` at line 87. The value is never used—the variable is either overwritten with the actual embedding data, or the loop is exited early in the event of a missing embedding. The best way to fix is to declare the variable without an initializer, i.e., just `ReadOnlyMemory<float> embedding;`. This avoids any accidental use of an uninitialized value, and fits the usage pattern present in the code. Only one line (87) needs to be changed, and no additional imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
